### PR TITLE
Add forward integration capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ InstallInstructions.txt
 
 # deprecated code
 build/*
+buildnew/*
 .legacy*
 
 # non-public examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # using Visual Studio C++
 endif()
 
-set(CMAKE_OSX_ARCHITECTURES "x86_64")
+#set(CMAKE_OSX_ARCHITECTURES "x86_64")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(
   MWLMC
-  VERSION 2.0.0
+  VERSION 1.1.0
   HOMEPAGE_URL https://github.com/sophialilleengen/mwlmc
   LANGUAGES CXX)
 

--- a/include/common/orient.h
+++ b/include/common/orient.h
@@ -43,7 +43,7 @@ struct SphOrient
 {
 
   bool inertial=true;   // stick with inertial centre (default true)?
-  bool eventime=true;   // check spacing of orient timing (assume equal)
+  bool eventime=false;   // check spacing of orient timing (assume equal)
 
   int NUMT;             // the number of timesteps
   vector<double> time;  // the time vector, len NUMT

--- a/include/sphere/sphcache.h
+++ b/include/sphere/sphcache.h
@@ -152,97 +152,17 @@ void init_table(SphModel& sphmodel, SphCache& cachetable)
 }
 
 
-
-
-void get_pot(double& r, SphCache& cachetable, MatrixXd& pottable)
+void get_pot_force_density(double& r, SphCache& cachetable, MatrixXd& pottable, MatrixXd& forcetable, MatrixXd& densitytable)
 {
   /*
   double r : radius position to query functions
   cachetable: table with values for interpolating
   pottable: table that wil lbe filled in with potential values
+  forcetable: table that will be filled in with force values
+  densitytable: table that will be filled in with density values
   */
   pottable.resize(cachetable.LMAX+1,cachetable.NMAX);
-
-  double xi;
-  xi = r_to_xi(r, cachetable.CMAP, cachetable.SCL);
-
-  if (cachetable.CMAP==1) {
-        if (xi<-1.0) xi=-1.0;
-        if (xi>=1.0) xi=1.0-1.0e-08;
-  }
-
-  int indx = (int)( (xi-cachetable.xmin)/cachetable.dxi );
-  if (indx<0) indx = 0;
-  if (indx>cachetable.NUMR-2) indx = cachetable.NUMR - 2;
-
-  double x1 = (cachetable.xi[indx+1] - xi)/cachetable.dxi;
-  double x2 = (xi - cachetable.xi[indx])/cachetable.dxi;
-
-  for (int l=0; l<=cachetable.LMAX; l++) {
-    for (int n=0; n<cachetable.NMAX; n++) {
-
-      pottable(l,n) = (x1*cachetable.eftable[l](n,indx) + x2*cachetable.eftable[l](n,indx+1))/
-	       sqrt(cachetable.evtable(l,n)) * (x1*cachetable.p0[indx] + x2*cachetable.p0[indx+1]);
-
-    }
-  }
-}
-
-
-void get_force(double& r, SphCache& cachetable, MatrixXd& forcetable) {
-  /*
-  double r : radius position to query functions
-  cachetable: table with values for interpolating
-  pottable: table that wil lbe filled in with potential values
-
-  see the equivalent call, get_force in SLGridMP2.cc
-
-  must have already run init_table
-  */
-
-
   forcetable.resize(cachetable.LMAX+1,cachetable.NMAX);
-
-  double xi;
-  xi = r_to_xi(r, cachetable.CMAP, cachetable.SCL);
-
-  // how can this happen?
-  //if (cachetable.CMAP==1) {
-  //      if (xi<-1.0) xi=-1.0;
-  //      if (xi>=1.0) xi=1.0-1.0e-08;
-  //}
-
-  int indx = (int)( (xi-cachetable.xmin)/cachetable.dxi );
-
-  // bounds checks
-  if (indx<1) indx = 1;
-  if (indx>cachetable.NUMR-2) indx = cachetable.NUMR - 2;
-
-  double p = (xi - cachetable.xi[indx])/cachetable.dxi;
-
-	// Use three point formula
-
-	// Point -1: indx-1
-	// Point  0: indx
-	// Point  1: indx+1
-
-  for (int l=0; l<=cachetable.LMAX; l++) {
-    for (int n=0; n<cachetable.NMAX; n++) {
-      forcetable(l,n) = d_xi_to_r(xi,cachetable.CMAP,cachetable.SCL)/cachetable.dxi * (
-			     (p - 0.5)*cachetable.eftable[l](n,indx-1)*cachetable.p0[indx-1]
-			     -2.0*p*cachetable.eftable[l](n,indx)*cachetable.p0[indx]
-			     + (p + 0.5)*cachetable.eftable[l](n,indx+1)*cachetable.p0[indx+1]
-         ) / sqrt(cachetable.evtable(l,n));
-    }
-  }
-
-}
-
-void get_density(double& r, SphCache& cachetable, MatrixXd& densitytable)
-{
-
-  // see equivalent call in SLGridMP2.cc
-
   densitytable.resize(cachetable.LMAX+1,cachetable.NMAX);
 
   double xi;
@@ -259,12 +179,23 @@ void get_density(double& r, SphCache& cachetable, MatrixXd& densitytable)
 
   double x1 = (cachetable.xi[indx+1] - xi)/cachetable.dxi;
   double x2 = (xi - cachetable.xi[indx])/cachetable.dxi;
-
-  //cout << cachetable.d0[indx] << endl;
-
+  //double p = (xi - cachetable.xi[indx])/cachetable.dxi;
 
   for (int l=0; l<=cachetable.LMAX; l++) {
     for (int n=0; n<cachetable.NMAX; n++) {
+
+      pottable(l,n) = (x1*cachetable.eftable[l](n,indx) + x2*cachetable.eftable[l](n,indx+1))/
+         sqrt(cachetable.evtable(l,n)) * (x1*cachetable.p0[indx] + x2*cachetable.p0[indx+1]);
+
+      // Use three point formula
+      // Point -1: indx-1
+      // Point  0: indx
+      // Point  1: indx+1
+      forcetable(l,n) = d_xi_to_r(xi,cachetable.CMAP,cachetable.SCL)/cachetable.dxi * (
+			     (x2 - 0.5)*cachetable.eftable[l](n,indx-1)*cachetable.p0[indx-1]
+			     -2.0*x2*cachetable.eftable[l](n,indx)*cachetable.p0[indx]
+			     + (x2 + 0.5)*cachetable.eftable[l](n,indx+1)*cachetable.p0[indx+1]
+         ) / sqrt(cachetable.evtable(l,n));  
 
       // negative for normalisation
       densitytable(l,n) = -(x1*cachetable.eftable[l](n,indx) + x2*cachetable.eftable[l](n,indx+1)) *
@@ -278,16 +209,14 @@ void get_density(double& r, SphCache& cachetable, MatrixXd& densitytable)
 void get_dpotl(double r, SphCache& cachetable, MatrixXd& potd, MatrixXd& dpot)
 {
   // r comes in as the actual radius, NOT xi
-  get_pot  (r, cachetable, potd);
-  get_force(r, cachetable, dpot);
+  MatrixXd dummydens;
+  get_pot_force_density(r, cachetable, potd, dpot, dummydens);
 }
 
 void get_dpotl_density(double r, SphCache& cachetable, MatrixXd& potd, MatrixXd& dpot, MatrixXd& dend)
 {
   // r comes in as the actual radius, NOT xi
-  get_pot  (r, cachetable, potd);
-  get_force(r, cachetable, dpot);
-  get_density(r, cachetable, dend);
+  get_pot_force_density(r, cachetable, potd, dpot, dend);
 }
 
 #endif

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ class CMakeBuild(build_ext):
 # logic and declaration, and simpler if you include description/version in a file.
 setup(
     name="mwlmc", 
-    version="1.0.1",
+    version="1.1.0",
     packages=["mwlmc", "mwlmc.util", "mwlmc.plot"],
     # py_modules = ['mwlmc.util', 'mwlmc.plot'],
     ext_package="mwlmc",

--- a/src/fullintegrate.h
+++ b/src/fullintegrate.h
@@ -160,6 +160,25 @@ public:
                                   bool discframe = true,
                                   bool verbose = false);
 
+
+   MatrixXd forward(vector<double> xinit,
+                   vector<double> vinit,
+                   double dt=0.002,
+                   int mwhharmonicflag=127, int mwdharmonicflag=127, int lmcharmonicflag=127,
+                   double start_time=-1.0,
+                   double end_time=0.0,
+                   bool discframe = true,
+                   bool verbose = false);
+
+   std::vector< MatrixXd > forward(MatrixXd xinit,
+                   MatrixXd vinit,
+                   double dt=0.002,
+                   int mwhharmonicflag=127, int mwdharmonicflag=127, int lmcharmonicflag=127,
+                   double start_time=-1.0,
+                   double end_time=0.0,
+                   bool discframe = true,
+                   bool verbose = false);
+
   // get the LMC trajectory (relative to the MW disc centre)
   MatrixXd get_lmc_trajectory(double rewindtime=2.5,double dt=native_timestep);
 
@@ -2374,6 +2393,357 @@ std::vector< MatrixXd > MWLMC::rewind(MatrixXd xinit,
  return orbit;
 
 }
+
+
+
+
+MatrixXd MWLMC::forward(vector<double> xinit,
+                       vector<double> vinit,
+                       double dt,
+                       int mwhharmonicflag, int mwdharmonicflag, int lmcharmonicflag,
+                       double start_time,
+                       double end_time,
+                       bool discframe,
+                       bool verbose)
+{
+ /*
+ forward
+ -------------
+ for a given position and velocity, run the orbit forward by a specified amount of time
+
+ takes physical units
+
+  */
+
+  // step 0: allocate workspace
+  double fx,fy,fz,tvir;
+
+  // check if start time is positive: it needs to be defined negative!
+  if (start_time > 0) {
+    std::cerr << "forward: start_time must be negative. Exiting." << std::endl;
+    exit(-1);
+  }
+
+  // also check end time: if greater than zero, set to zero
+  if (end_time > 0) {
+    end_time = 0.;
+    // and warn user
+    std::cerr << "forward: end_time must be negative. Setting to 0." << std::endl;
+  }
+
+  // also check that the end time is greater than the start time
+  if (end_time < start_time) {
+    std::cerr << "forward: end_time must be greater than start_time. Exiting." << std::endl;
+    exit(-1);
+  }
+
+  // number of integration steps to take
+  int nint = (int)((end_time-start_time)/dt);
+
+  // step 1: get the coordinate frame of the MW disc: the absolute frame of the system
+  vector<double> disccoords(3),discvelcoords(3);
+  vector<double> initcoords(3),initvelcoords(3);
+  return_centre(reference_time+physical_to_virial_time_return(start_time), MWD->orient, initcoords);
+  return_vel_centre(reference_time+physical_to_virial_time_return(start_time), MWD->orient, initvelcoords);
+
+  if (verbose) {
+    std::cout << setw(14) << reference_time+physical_to_virial_time_return(start_time)
+              << setw(14) << virial_to_physical_length(initcoords[0])
+              << setw(14) << virial_to_physical_length(initcoords[1])
+              << setw(14) << virial_to_physical_length(initcoords[2]) << std::endl;
+    std::cout << setw(14) << "(u,v,w)"
+              << setw(14) << virial_to_physical_velocity(initvelcoords[0])
+              << setw(14) << virial_to_physical_velocity(initvelcoords[1])
+              << setw(14) << virial_to_physical_velocity(initvelcoords[2]) << std::endl;
+    std::cout << "start_time = " << start_time << std::endl;
+    std::cout << "end_time = " << end_time << std::endl;
+    std::cout << "dt = " << dt << std::endl;
+    std::cout << "nint = " << nint << std::endl;
+  }
+
+  // step 2: set beginning times and timesteps
+  double tvirbegin  = reference_time+physical_to_virial_time_return(start_time);
+  double dtvir      = physical_to_virial_time_return(dt);
+  double tphysbegin = 0.;
+  double dtphys     = dt;
+
+
+  // make the output frame
+  MatrixXd orbit;
+  orbit.resize(10,nint);
+
+  // initialise positions and (inverted) velocities for backwards integration
+  // these are all in physical units
+  orbit(0,0) =  xinit[0]+virial_to_physical_length(initcoords[0]);
+  orbit(1,0) =  xinit[1]+virial_to_physical_length(initcoords[1]);
+  orbit(2,0) =  xinit[2]+virial_to_physical_length(initcoords[2]);
+  orbit(3,0) =  vinit[0];
+  orbit(4,0) =  vinit[1];
+  orbit(5,0) =  vinit[2];
+  //6-8 are forces, set below...
+  orbit(9,0) = tphysbegin;
+
+  //now step forward one, using leapfrog (drift-kick-drift) integrator
+  //    https://en.wikipedia.org/wiki/Leapfrog_integration
+  //
+  int step = 1;
+
+  // get the initial coefficient values: the time here is in tvir units, so always start with 0
+  MatrixXd tcoefsmw,tcoefslmc, mwcoscoefs,mwsincoefs;
+  MW->select_coefficient_time(tvirbegin, tcoefsmw);
+  LMC->select_coefficient_time(tvirbegin, tcoefslmc);
+  MWD->select_coefficient_time(tvirbegin, mwcoscoefs, mwsincoefs);
+
+  // return forces for the initial step.
+  all_forces_coefs(tcoefsmw, tcoefslmc, mwcoscoefs, mwsincoefs,
+                  tphysbegin, orbit(0,0),orbit(1,0),orbit(2,0),
+                  fx, fy, fz,
+                  mwhharmonicflag, mwdharmonicflag, lmcharmonicflag);
+
+  orbit(6,0) = fx;
+  orbit(7,0) = fy;
+  orbit(8,0) = fz;
+
+  int j;
+  double tvirnow, tphysnow;
+
+  for (step=1; step<nint; step++) {
+
+    // 'advance' timestep: this is in virial units by definition.
+    tvirnow  = tvirbegin  + dtvir*step;
+    tphysnow = tphysbegin + dtphys*step;
+    orbit(9,step) = tphysnow; // record the time
+
+    MW->select_coefficient_time(tvirnow, tcoefsmw);
+    LMC->select_coefficient_time(tvirnow, tcoefslmc);
+    MWD->select_coefficient_time(tvirnow, mwcoscoefs, mwsincoefs);
+
+    // 'advance' positions
+    for (j=0; j<3; j++) {
+      orbit(j,step) = orbit(j,step-1)   + (orbit(j+3,step-1)*dt  )  + (0.5*orbit(j+6,step-1)  * (dt*dt));
+    }
+
+    // this call goes out in PHYSICAL units
+    all_forces_coefs(tcoefsmw, tcoefslmc, mwcoscoefs, mwsincoefs,
+                     // need to shift the time by one unit to get the proper centre
+                     tphysnow + dtphys, orbit(0,step),orbit(1,step),orbit(2,step),
+                     fx, fy, fz,
+                     mwhharmonicflag, mwdharmonicflag, lmcharmonicflag);
+
+
+   orbit(6,step) = fx;
+   orbit(7,step) = fy;
+   orbit(8,step) = fz;
+
+   // advance velocities
+   for (j=3; j<6; j++) {
+     orbit(j,step) = orbit(j,step-1) + (0.5*(orbit(j+3,step-1)+orbit(j+3,step))  * dt );
+   }
+
+ }
+
+
+ // convert to physical units again...
+ if (discframe) {
+   for (int n=0; n<nint; n++) {
+     tvirnow  = tvirbegin + dtvir*n;
+     // get the present-day MWD coordinates: the zero of the total
+     return_centre(tvirnow, MWD->orient, disccoords);
+     //std::cout << setw(14) << tvirnow  << setw(14) << zerocoords[0] << setw(14) << zerocoords[1] << setw(14) << zerocoords[2] << std::endl;
+     return_vel_centre(tvirnow, MWD->orient, discvelcoords);
+     for (j=0; j<3; j++) {
+       orbit(j,n)   = orbit(j,n) - virial_to_physical_length(disccoords[j]);
+       orbit(j+3,n) = orbit(j+3,n) - virial_to_physical_velocity(discvelcoords[j]);
+     }
+   }
+ }
+
+ return orbit;
+
+}
+
+
+
+
+std::vector< MatrixXd > MWLMC::forward(MatrixXd xinit,
+                                       MatrixXd vinit,
+                                       double dt,
+                                       int mwhharmonicflag, int mwdharmonicflag, int lmcharmonicflag,
+                                       double start_time,
+                                       double end_time,
+                                       bool discframe,
+                                       bool verbose)
+{
+ /*
+ forward
+ -------------
+ for a given position and velocity, run the orbit forward by a specified amount of time
+
+ takes physical units
+
+  */
+
+  // step 0: allocate workspace
+  double fx,fy,fz,tvir;
+
+  // check if start time is positive: it needs to be defined negative!
+  if (start_time > 0) {
+    std::cerr << "forward: start_time must be negative. Exiting." << std::endl;
+    exit(-1);
+  }
+
+  // also check end time: if greater than zero, set to zero
+  if (end_time > 0) {
+    end_time = 0.;
+    // and warn user
+    std::cerr << "forward: end_time must be negative. Setting to 0." << std::endl;
+  }
+
+  // also check that the end time is greater than the start time
+  if (end_time < start_time) {
+    std::cerr << "forward: end_time must be greater than start_time. Exiting." << std::endl;
+    exit(-1);
+  }
+
+  // number of integration steps to take
+  int nint = (int)((end_time-start_time)/dt);
+
+  // step 1: get the coordinate frame of the MW disc: the absolute frame of the system
+  vector<double> disccoords(3),discvelcoords(3);
+  vector<double> initcoords(3),initvelcoords(3);
+  return_centre(reference_time+physical_to_virial_time_return(start_time), MWD->orient, initcoords);
+  return_vel_centre(reference_time+physical_to_virial_time_return(start_time), MWD->orient, initvelcoords);
+
+  if (verbose) {
+    std::cout << setw(14) << reference_time+physical_to_virial_time_return(start_time)
+              << setw(14) << virial_to_physical_length(initcoords[0])
+              << setw(14) << virial_to_physical_length(initcoords[1])
+              << setw(14) << virial_to_physical_length(initcoords[2]) << std::endl;
+    std::cout << setw(14) << "(u,v,w)"
+              << setw(14) << virial_to_physical_velocity(initvelcoords[0])
+              << setw(14) << virial_to_physical_velocity(initvelcoords[1])
+              << setw(14) << virial_to_physical_velocity(initvelcoords[2]) << std::endl;
+    std::cout << "start_time = " << start_time << std::endl;
+    std::cout << "end_time = " << end_time << std::endl;
+    std::cout << "dt = " << dt << std::endl;
+    std::cout << "nint = " << nint << std::endl;
+  }
+
+  // step 2: set beginning times and timesteps
+  double tvirbegin  = reference_time+physical_to_virial_time_return(start_time);
+  double dtvir      = physical_to_virial_time_return(dt);
+  double tphysbegin = 0.;
+  double dtphys     = dt;
+
+
+  // make the output frame
+  int norbits = xinit.rows();
+  std::vector< MatrixXd > orbit;
+  orbit.resize(norbits);
+
+  // initialise positions and (inverted) velocities for backwards integration
+  // include the forces for now
+  for (int n=0;n<norbits;n++) {
+    orbit[n].resize(10,nint);
+    orbit[n](0,0) =  xinit(n,0)+virial_to_physical_length(initcoords[0]);
+    orbit[n](1,0) =  xinit(n,1)+virial_to_physical_length(initcoords[1]);
+    orbit[n](2,0) =  xinit(n,2)+virial_to_physical_length(initcoords[2]);
+    orbit[n](3,0) =  vinit(n,0);
+    orbit[n](4,0) =  vinit(n,1);
+    orbit[n](5,0) =  vinit(n,2);
+    orbit[n](9,0) =  tphysbegin;
+  }
+
+  //now step forward one, using leapfrog (drift-kick-drift) integrator
+  //    https://en.wikipedia.org/wiki/Leapfrog_integration
+  //
+  int step = 1;
+
+  // get the initial coefficient values: the time here is in tvir units, so always start with 0
+  MatrixXd tcoefsmw,tcoefslmc, mwcoscoefs,mwsincoefs;
+  MW->select_coefficient_time(tvirbegin, tcoefsmw);
+  LMC->select_coefficient_time(tvirbegin, tcoefslmc);
+  MWD->select_coefficient_time(tvirbegin, mwcoscoefs, mwsincoefs);
+
+  // return forces for the initial step.
+  for (int n=0;n<norbits;n++) {
+    // this call goes out in physical units
+    all_forces_coefs(tcoefsmw, tcoefslmc, mwcoscoefs, mwsincoefs,
+                  tphysbegin, orbit[n](0,0),orbit[n](1,0),orbit[n](2,0),
+                  fx, fy, fz,
+                  mwhharmonicflag, mwdharmonicflag, lmcharmonicflag);
+
+    orbit[n](6,0) = fx;
+    orbit[n](7,0) = fy;
+    orbit[n](8,0) = fz;
+  }
+
+  int j;
+  double tvirnow, tphysnow;
+
+  for (step=1; step<nint; step++) {
+
+    // 'advance' timestep: this is in virial units by definition.
+    tvirnow  = tvirbegin  + dtvir*step;
+    tphysnow = tphysbegin + dtphys*step;
+
+    MW->select_coefficient_time(tvirnow, tcoefsmw);
+    LMC->select_coefficient_time(tvirnow, tcoefslmc);
+    MWD->select_coefficient_time(tvirnow, mwcoscoefs, mwsincoefs);
+
+    for (int n=0;n<norbits;n++) {
+      orbit[n](9,step) = tphysnow; // record the time
+    
+      // advance positions
+      for (j=0; j<3; j++) {
+        orbit[n](j,step) = orbit[n](j,step-1)   + (orbit[n](j+3,step-1)*dt  )  + (0.5*orbit[n](j+6,step-1)  * (dt*dt));
+      }
+
+      // this call goes out in PHYSICAL units
+      all_forces_coefs(tcoefsmw, tcoefslmc, mwcoscoefs, mwsincoefs,
+                     // need to shift the time by one unit to get the proper centre
+                     tphysnow + dtphys, orbit[n](0,step),orbit[n](1,step),orbit[n](2,step),
+                     fx, fy, fz,
+                     mwhharmonicflag, mwdharmonicflag, lmcharmonicflag);
+
+
+    orbit[n](6,step) = fx;
+    orbit[n](7,step) = fy;
+    orbit[n](8,step) = fz;
+
+    // advance velocities
+    for (j=3; j<6; j++) {
+       orbit[n](j,step) = orbit[n](j,step-1) + (0.5*(orbit[n](j+3,step-1)+orbit[n](j+3,step))  * dt );
+    }
+  } //close orbit loop
+
+ }
+
+
+ // convert to physical units again...
+ if (discframe) {
+   for (int n=0; n<nint; n++) {
+     tvirnow  = tvirbegin + dtvir*n;
+     // get the present-day MWD coordinates: the zero of the total
+     return_centre(tvirnow, MWD->orient, disccoords);
+     //std::cout << setw(14) << tvirnow  << setw(14) << zerocoords[0] << setw(14) << zerocoords[1] << setw(14) << zerocoords[2] << std::endl;
+     return_vel_centre(tvirnow, MWD->orient, discvelcoords);
+     for (int n=0;n<norbits;n++) {
+       // shift the coordinates to the disc frame
+       // this is in physical units
+      for (j=0; j<3; j++) {
+        orbit[n](j,n)   = orbit[n](j,n) - virial_to_physical_length(disccoords[j]);
+        orbit[n](j+3,n) = orbit[n](j+3,n) - virial_to_physical_velocity(discvelcoords[j]);
+      }
+    } // orbit loop
+   }
+ }
+
+ return orbit;
+
+}
+
+
 
 
 #endif

--- a/src/mwlmc.cc
+++ b/src/mwlmc.cc
@@ -404,7 +404,71 @@ PYBIND11_MODULE(model, m) {
              py::arg("discframe")       = false,
              py::arg("verbose")         = false)
 
-        .def("print_orbit", &MWLMC::print_orbit, "print an orbit array")
+     .def("forward", py::overload_cast<vector<double>,vector<double>,double,int,int,int,double,double,bool,bool>(&MWLMC::forward),R"pbdoc(
+             Compute an orbit forward.
+
+             Parameters
+             ----------
+             xinit : array-like float
+             vinit : array-like float
+             dt : float = 0.002
+             mwhharmonicflag : int = 127
+             mwdharmonicflag : int = 127
+             lmcharmonicflag : int = 127
+             starttime : float = -1.0
+             endtime : float = 0.0
+
+             Returns
+             -------
+             x, y, z : array-like float
+             vx, vy, vz : array-like float
+             fx, fy, fz : array-like float
+             t : array-like float
+             )pbdoc",
+             py::arg("xinit"),
+             py::arg("vinit"),
+             py::arg("dt")              = 0.002,
+             py::arg("mwhharmonicflag") = 127,
+             py::arg("mwdharmonicflag") = 127,
+             py::arg("lmcharmonicflag") = 127,
+             py::arg("starttime")       = -1.0,
+             py::arg("endtime")         = 0.0,
+             py::arg("discframe")       = false,
+             py::arg("verbose")         = false)
+
+     .def("forward", py::overload_cast<MatrixXd,MatrixXd,double,int,int,int,double,double,bool,bool>(&MWLMC::forward),R"pbdoc(
+             Compute a group of orbits forward.
+
+             Parameters
+             ----------
+             xinit : array-like float
+             vinit : array-like float
+             dt : float = 0.002
+             mwhharmonicflag : int = 127
+             mwdharmonicflag : int = 127
+             lmcharmonicflag : int = 127
+             starttime : float = -1.0
+             endtime : float = 0.0
+
+             Returns
+             -------
+             x, y, z : array-like float
+             vx, vy, vz : array-like float
+             fx, fy, fz : array-like float
+             t : array-like float
+             )pbdoc",
+             py::arg("xinit"),
+             py::arg("vinit"),
+             py::arg("dt")              = 0.002,
+             py::arg("mwhharmonicflag") = 127,
+             py::arg("mwdharmonicflag") = 127,
+             py::arg("lmcharmonicflag") = 127,
+             py::arg("starttime")       = -1.0,
+             py::arg("endtime")         = 0.0,
+             py::arg("discframe")       = false,
+             py::arg("verbose")         = false)
+             
+     .def("print_orbit", &MWLMC::print_orbit, "print an orbit array")
 
         // no specific resets exposed as of now. could be exposed if this is a common use case.
         //.def("reset_mw_coefficients", &MWLMC::reset_mw_coefficients, "reset MW coefficients")


### PR DESCRIPTION

### Orbit Computation Enhancements:
* Added two overloaded `forward` methods in the `MWLMC` class to compute orbits forward in time for single and multiple initial conditions. These include validation, leapfrog integration, and support for physical and disc frames. [[1]](diffhunk://#diff-aa2d40d8b37b937180b593ca75daa926bf9a51eb9816b66bb93160c28ebb8533R163-R181) [[2]](diffhunk://#diff-aa2d40d8b37b937180b593ca75daa926bf9a51eb9816b66bb93160c28ebb8533R2398-R2748)
* Exposed the new `forward` methods to Python using Pybind11, allowing computation of forward orbits directly from Python.

### Spherical Cache Refactoring:
* Consolidated `get_pot`, `get_force`, and `get_density` into a single `get_pot_force_density` method for unified handling of potential, force, and density calculations. This simplifies the API and reduces code redundancy. [[1]](diffhunk://#diff-7b1e8b4d61b512a2850440f3dfc95b0d34fe00412e0a651135d64143785d021bL155-R166) [[2]](diffhunk://#diff-7b1e8b4d61b512a2850440f3dfc95b0d34fe00412e0a651135d64143785d021bL281-R219)
* Removed the standalone `get_force` and `get_density` methods, replacing their functionality with the new consolidated method.

### Other changes
* Can be ignored: I might recommend bumping the version to 2.1.0 in both `CMakeLists.txt` and `setup.py`, but not needed
* Changes to install can be ignored.
* Change to default time spacing helped with a very subtle bug in one case; not a generic problem (I don't think), but the change doesn't hurt.